### PR TITLE
docs: add attribution to original breadcrumbs repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,9 @@ you can jump back instantly and navigate your graph with confidence.**
 
 - `Max breadcrumbs`: max number of prior locations to keep
 - `Truncate length`: max label length before truncation
+
+## Acknowledgements
+
+- Hat tip to [Joel Chan](https://github.com/joelchan) for the original Breadcrumbs extension work.
+- Previous repository: [joelchan/roam-breadcrumbs-extension](https://github.com/joelchan/roam-breadcrumbs-extension)
+- Credit for prompting and testing support in this fork.


### PR DESCRIPTION
## Summary
- add an Acknowledgements section to README
- credit Joel Chan with profile link
- link to the original roam-breadcrumbs-extension repo
- include prompt/testing credit note

## Testing
- not run (docs-only change)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/roamjs/breadcrumbs/pull/6" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
